### PR TITLE
2D forward solver with animation 

### DIFF
--- a/2D_Forward_solver.py
+++ b/2D_Forward_solver.py
@@ -107,19 +107,16 @@ def assemble_jacobian(phi_new, dt, tau, c1, L):
     t = tau / dt
     s = 1.0 / dt
 
-    # K_phi_phi
     Kpp = (-0.5 * kappa) * L.tocsr()
     phi_sq = phi_new ** 2
-    diag_add = t + 2.0 * c1 / (1.0 - phi_sq)  # |phi|<1 enforced elsewhere
+    diag_add = t + 2.0 * c1 / (1.0 - phi_sq)
     Kpp = Kpp + sps.diags(diag_add, format="csr")
 
-    # K_phi_mu, K_mu_phi, K_mu_mu
     I = sps.eye(Nloc, format="csr")
     Kpm = -0.5 * I
     Kmp = s * I
     Kmm = -0.5 * L.tocsr()
 
-    # Block assembly
     J = sps.bmat([[Kpp, Kpm], [Kmp, Kmm]], format="csr")
     return J
 


### PR DESCRIPTION
## Summary
- extend grid and parameters for two-dimensional domain
- add 2D Neumann Laplacian, Jacobian assembly, and solver routines for flattened 2D fields
- duplicate solver into standalone `2D_Forward_solver.py`
- switch Laplacian and Newton solve to SciPy sparse matrices for efficiency
- generate and save a GIF animation of phase separation using Matplotlib

## Testing
- `python -m py_compile Forward_solver.py 2D_Forward_solver.py`
- `pip install scipy` *(fails: Could not find a version; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c81822988327b2dbcb8e4606c64e