### PR TITLE
Expand backward solver to 2D

### DIFF
--- a/2D_Forward_solver.py
+++ b/2D_Forward_solver.py
@@ -107,19 +107,16 @@ def assemble_jacobian(phi_new, dt, tau, c1, L):
     t = tau / dt
     s = 1.0 / dt
 
-    # K_phi_phi
     Kpp = (-0.5 * kappa) * L.tocsr()
     phi_sq = phi_new ** 2
-    diag_add = t + 2.0 * c1 / (1.0 - phi_sq)  # |phi|<1 enforced elsewhere
+    diag_add = t + 2.0 * c1 / (1.0 - phi_sq)
     Kpp = Kpp + sps.diags(diag_add, format="csr")
 
-    # K_phi_mu, K_mu_phi, K_mu_mu
     I = sps.eye(Nloc, format="csr")
     Kpm = -0.5 * I
     Kmp = s * I
     Kmm = -0.5 * L.tocsr()
 
-    # Block assembly
     J = sps.bmat([[Kpp, Kpm], [Kmp, Kmm]], format="csr")
     return J
 
@@ -266,13 +263,13 @@ def source_u(t, x, y):
 
     return np.zeros((x.size, y.size))
 
-def run_main_simulation(store_history=False, control_input=None, verbose=True):
+def run_main_simulation(store_history=False, control_input=None, verbose=True, seed=42):
 
 
     x = np.linspace(0, Lx, Nx + 1)
     y = np.linspace(0, Ly, Ny + 1)
     # initial phi inside (-1,1)
-    phi = init_phi_random(Nx, Ny, delta_sep, amp=0.01, seed=42, enforce_zero_mean=True).reshape(-1)
+    phi = init_phi_random(Nx, Ny, delta_sep, amp=0.01, seed=seed, enforce_zero_mean=True).reshape(-1)
 
     w = np.zeros_like(phi)
 
@@ -391,10 +388,21 @@ def run_main_simulation(store_history=False, control_input=None, verbose=True):
         return None
 
 
-def save_phase_separation_animation(filename="phase_separation.gif", fps=20):
-    """Run the simulation, create an animation, and save it to ``filename``."""
+def save_phase_separation_animation(filename="phase_separation.gif", fps=20, seed=42):
+    """Run the simulation, create an animation, and save it to ``filename``.
 
-    history, (x, y), t_hist = run_main_simulation(store_history=True, verbose=False)
+    Parameters
+    ----------
+    filename : str
+        Output GIF file name.
+    fps : int
+        Frames per second in the saved animation.
+    seed : int
+        Random seed for the initial condition; different seeds produce
+        distinct phase-separation patterns.
+    """
+
+    history, (x, y), t_hist = run_main_simulation(store_history=True, verbose=False, seed=seed)
 
     fig, ax = plt.subplots(figsize=(6, 5))
     im = ax.imshow(history[0], origin="lower", extent=[0, Lx, 0, Ly], vmin=-1, vmax=1)

--- a/backward_solver.py
+++ b/backward_solver.py
@@ -1,82 +1,133 @@
+"""2D backward (adjoint) solver for the viscous Cahn–Hilliard system.
 
+This module expects a pre-computed forward solution `phi_hist` over a
+two-dimensional grid and marches the adjoint variables `p`, `q`, and `r`
+backward in time.  All spatial operators are assembled with SciPy sparse
+matrices to handle larger grids efficiently.
 
-# In backward_solver_fixed.py
+The forward solver provides the material parameters `c1`, `c2`, `tau`, and
+`gamma`, as well as the 2‑D Neumann Laplacian builder
+`laplacian_matrix_neumann`.
+"""
+
+from __future__ import annotations
+
 import numpy as np
-from typing import Tuple, Optional
+import scipy.sparse as sps
+from scipy.sparse.linalg import spsolve
+from typing import Optional, Tuple
+
 from Forward_solver import (
     laplacian_matrix_neumann,
-    c1, c2, tau, gamma,
+    c1,
+    c2,
+    tau,
+    gamma,
 )
 
+
 def fpp_log(phi: np.ndarray, eps: float = 1e-8) -> np.ndarray:
-    """Second derivative of the logarithmic potential with safety clipping"""
+    """Second derivative of the logarithmic potential with safety clipping."""
+
     ph = np.clip(phi, -1 + eps, 1 - eps)
     return 2.0 * c1 / (1.0 - ph**2) - 2.0 * c2
+
 
 def run_backward(
     phi_hist: np.ndarray,
     x: np.ndarray,
+    y: np.ndarray,
     t_hist: np.ndarray,
     b1: float,
     b2: float,
     phi_Q: Optional[np.ndarray] = None,
     phi_T_target: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Solve the adjoint system backward in time on a 2‑D grid.
+
+    Parameters
+    ----------
+    phi_hist:
+        Array of shape ``(M+1, Nx+1, Ny+1)`` containing the forward solution.
+    x, y:
+        1‑D spatial grids of length ``Nx+1`` and ``Ny+1`` respectively.
+    t_hist:
+        Monotonically increasing time levels of length ``M+1``.
+    b1, b2:
+        Objective functional weights.
+    phi_Q, phi_T_target:
+        Optional target fields with the same shapes as ``phi_hist`` and the
+        final ``phi`` slice respectively.
     """
-    Solve the adjoint system backward in time using a pre-computed forward solution.
-    """
-    M_plus1, N_plus1 = phi_hist.shape
-    
-    # --- Setup Targets ---
+
+    M_plus1, Nx1, Ny1 = phi_hist.shape
+    Nx = Nx1 - 1
+    Ny = Ny1 - 1
+    hx = x[1] - x[0]
+    hy = y[1] - y[0]
+    Nloc = (Nx + 1) * (Ny + 1)
+
+    # Flatten spatial fields for linear algebra operations
+    phi_hist_f = phi_hist.reshape(M_plus1, Nloc)
+
     if phi_Q is None:
-        phi_Q = np.zeros_like(phi_hist)
+        phi_Q_f = np.zeros_like(phi_hist_f)
+    else:
+        phi_Q_f = phi_Q.reshape(M_plus1, Nloc)
+
     if phi_T_target is None:
-        phi_T_target = np.zeros(N_plus1)
-    
-    # --- Grid and Operators ---
-    h = x[1] - x[0]
-    dts = np.diff(t_hist)
-    L = laplacian_matrix_neumann(N_plus1 - 1, h)
+        phi_T_f = np.zeros(Nloc)
+    else:
+        phi_T_f = phi_T_target.reshape(Nloc)
+
+    # --- Grid operators ---
+    L = laplacian_matrix_neumann(Nx, Ny, hx, hy)  # sparse CSR
     L2 = L @ L
-    I = np.eye(N_plus1)
-    
-    # --- Allocate Adjoints ---
-    p = np.zeros_like(phi_hist)
-    q = np.zeros_like(phi_hist)
-    r = np.zeros_like(phi_hist)
-    
-    # --- Terminal Conditions at t=T ---
-    rhs_T = b2 * (phi_hist[-1] - phi_T_target)
-    p[-1] = np.linalg.solve(I - tau * L, rhs_T)
+    I = sps.eye(Nloc, format="csr")
+
+    # --- Allocate adjoint arrays (flattened) ---
+    p = np.zeros((M_plus1, Nloc))
+    q = np.zeros_like(p)
+    r = np.zeros_like(p)
+
+    # --- Terminal conditions at t = T ---
+    rhs_T = b2 * (phi_hist_f[-1] - phi_T_f)
+    p[-1] = spsolve(I - tau * L, rhs_T)
     q[-1] = -L @ p[-1]
-    r[-1] = np.zeros(N_plus1)
-    
-    # --- Adjoint Operators ---
-    def A_adjoint(phi_n, dt_n):
-        fpp_diag = np.diag(fpp_log(phi_n))
-        return I - tau*L + 0.5*dt_n*L2 - 0.5*dt_n*(fpp_diag @ L)
-    
-    def B_adjoint(phi_np1, dt_n):
-        fpp_diag = np.diag(fpp_log(phi_np1))
-        return I - tau*L - 0.5*dt_n*L2 + 0.5*dt_n*(fpp_diag @ L)
+    r[-1] = np.zeros(Nloc)
 
-    # --- Backward Time March ---
+    # --- Adjoint operators ---
+    def A_adjoint(phi_n: np.ndarray, dt_n: float) -> sps.csr_matrix:
+        fpp_vals = fpp_log(phi_n)
+        return I - tau * L + 0.5 * dt_n * L2 - 0.5 * dt_n * (sps.diags(fpp_vals) @ L)
+
+    def B_adjoint(phi_np1: np.ndarray, dt_n: float) -> sps.csr_matrix:
+        fpp_vals = fpp_log(phi_np1)
+        return I - tau * L - 0.5 * dt_n * L2 + 0.5 * dt_n * (sps.diags(fpp_vals) @ L)
+
+    # --- Backward time march ---
     for n in range(M_plus1 - 2, -1, -1):
-        dt_n = t_hist[n+1] - t_hist[n]
-        if dt_n <= 0: continue
+        dt_n = t_hist[n + 1] - t_hist[n]
+        if dt_n <= 0:
+            continue
 
-        src = 0.5 * dt_n * b1 * ((phi_hist[n] - phi_Q[n]) + (phi_hist[n+1] - phi_Q[n+1]))
-        rhs = B_adjoint(phi_hist[n+1], dt_n) @ p[n+1] + src
-        
+        src = 0.5 * dt_n * b1 * (
+            (phi_hist_f[n] - phi_Q_f[n]) + (phi_hist_f[n + 1] - phi_Q_f[n + 1])
+        )
+        rhs = B_adjoint(phi_hist_f[n + 1], dt_n) @ p[n + 1] + src
+
         try:
-            p[n] = np.linalg.solve(A_adjoint(phi_hist[n], dt_n), rhs)
-        except np.linalg.LinAlgError:
-            p[n] = np.linalg.solve(A_adjoint(phi_hist[n], dt_n) + 1e-10*I, rhs)
-        
-        q[n] = -L @ p[n]
-        
-        gamma_factor_back = (gamma - 0.5*dt_n) / (gamma + 0.5*dt_n)
-        gamma_factor_source = (dt_n * 0.5) / (gamma + 0.5*dt_n)
-        r[n] = gamma_factor_back * r[n+1] + gamma_factor_source * (q[n] + q[n+1])
+            p[n] = spsolve(A_adjoint(phi_hist_f[n], dt_n), rhs)
+        except Exception:
+            p[n] = spsolve(A_adjoint(phi_hist_f[n], dt_n) + 1e-10 * I, rhs)
 
-    return p, q, r
+        q[n] = -L @ p[n]
+
+        gamma_factor_back = (gamma - 0.5 * dt_n) / (gamma + 0.5 * dt_n)
+        gamma_factor_source = (0.5 * dt_n) / (gamma + 0.5 * dt_n)
+        r[n] = gamma_factor_back * r[n + 1] + gamma_factor_source * (q[n] + q[n + 1])
+
+    # Reshape adjoints back to (M+1, Nx+1, Ny+1)
+    shape3d = (M_plus1, Nx + 1, Ny + 1)
+    return p.reshape(shape3d), q.reshape(shape3d), r.reshape(shape3d)
+

--- a/forward_solver_mpi.py
+++ b/forward_solver_mpi.py
@@ -1,0 +1,29 @@
+from mpi4py import MPI
+import importlib
+
+# 2D_Forward_solver has a filename beginning with a digit, so load it dynamically
+solver = importlib.import_module("2D_Forward_solver")
+
+def main():
+    """Run multiple independent phase-separation simulations across MPI ranks.
+
+    Each rank uses a unique random seed and writes its own GIF to avoid file
+    conflicts. Results are named ``phase_separation_rankX.gif`` where ``X`` is
+    the MPI rank.
+    """
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    if rank == 0:
+        print(f"Launching {size} simulations across MPI ranks")
+
+    filename = f"phase_separation_rank{rank}.gif"
+    seed = 42 + rank
+    solver.save_phase_separation_animation(filename=filename, seed=seed)
+
+    if rank == 0:
+        print("All simulations completed.")
+
+if __name__ == "__main__":
+    main()

--- a/run_forward_solver.pbs
+++ b/run_forward_solver.pbs
@@ -1,0 +1,13 @@
+#!/bin/bash
+#PBS -N phase_sep
+#PBS -q teachingq
+#PBS -l select=1:ncpus=16:mpiprocs=16:mem=2GB
+#PBS -l walltime=00:30:00
+#PBS -o log.out
+#PBS -e log.err
+
+module load python
+module load mpi
+
+cd $PBS_O_WORKDIR
+mpirun -np 16 python forward_solver_mpi.py


### PR DESCRIPTION
## Summary
- generalize backward solver to operate on 2D grids using sparse SciPy matrices
- accept x/y grids and reshape adjoint outputs to full `(M+1, Nx+1, Ny+1)` arrays

## Testing
- `python -m py_compile backward_solver.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c81822988327b2dbcb8e4606c64e